### PR TITLE
CMakeLists: bump CMake minimum version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 INCLUDE(CheckIncludeFiles)
 
 PROJECT(quectel-timesync C)


### PR DESCRIPTION
Bump CMake minimum version to 3.10 to support CMake >= 4.0.

CMake now require 3.5 as the minimum version with that increased to 3.10 in the next CMake versions. Set to 3.10 to future-proof it.